### PR TITLE
Time blink on TIME_FORMAT without seconds

### DIFF
--- a/src/Frames.h
+++ b/src/Frames.h
@@ -110,6 +110,23 @@ void TimeFrame(FastLED_NeoMatrix *matrix, MatrixDisplayUiState *state, int16_t x
     struct tm *timeInfo;
     timeInfo = localtime(&now);
     char t[20];
+    if (now % 2) {
+        if (TIME_FORMAT == "%H:%M") {
+            TIME_FORMAT = "%H %M";
+        } else if (TIME_FORMAT == "%l:%M") {
+            TIME_FORMAT = "%l %M";
+        } else if (TIME_FORMAT == "%l:%M %p") {
+            TIME_FORMAT = "%l %M %p";
+        }
+    } else {
+        if (TIME_FORMAT == "%H %M") {
+            TIME_FORMAT = "%H:%M";
+        } else if (TIME_FORMAT == "%l %M") {
+            TIME_FORMAT = "%l:%M";
+        } else if (TIME_FORMAT == "%l %M %p") {
+            TIME_FORMAT = "%l:%M %p";
+        }
+    }
     strftime(t, sizeof(t), TIME_FORMAT.c_str(), localtime(&now));
     DisplayManager.printText(0 + x, 6 + y, t, true, false);
 

--- a/src/MenuManager.cpp
+++ b/src/MenuManager.cpp
@@ -129,6 +129,23 @@ String MenuManager_::menutext()
     case AppTimeMenu:
         return String(TIME_PER_APP / 1000.0, 0) + "s";
     case TimeFormatMenu:
+        if (now % 2) {
+            if (timeFormat[timeFormatIndex] == "%H:%M") {
+                timeFormat[timeFormatIndex] = "%H %M";
+            } else if (timeFormat[timeFormatIndex] == "%l:%M") {
+                timeFormat[timeFormatIndex] = "%l %M";
+            } else if (timeFormat[timeFormatIndex] == "%l:%M %p") {
+                timeFormat[timeFormatIndex] = "%l %M %p";
+            }
+        } else {
+            if (timeFormat[timeFormatIndex] == "%H %M") {
+                timeFormat[timeFormatIndex] = "%H:%M";
+            } else if (timeFormat[timeFormatIndex] == "%l %M") {
+                timeFormat[timeFormatIndex] = "%l:%M";
+            } else if (timeFormat[timeFormatIndex] == "%l %M %p") {
+                timeFormat[timeFormatIndex] = "%l:%M %p";
+            }
+        }
         strftime(t, sizeof(t), timeFormat[timeFormatIndex], localtime(&now));
         return t;
     case DateFormatMenu:


### PR DESCRIPTION
Thanks again for adding the new TIME_FORMATs. This PR is an attempt to blink the `:` on those time formats without seconds. 

I'm not a C++ expert, so if this is too ugly you can deny the PR. 