### PR TITLE
fixed: bufferAccessOutOfBounds/memleak by writing 23+1 chars into a 1…

### DIFF
--- a/src/MQTTManager.cpp
+++ b/src/MQTTManager.cpp
@@ -358,7 +358,7 @@ void MQTTManager_::setup()
         uint8_t mac[6];
         WiFi.macAddress(mac);
         char *macStr = new char[18 + 1];
-        snprintf(macStr, 24, "%02x%02x%02x", mac[3], mac[4], mac[5]);
+        snprintf(macStr, 18, "%02x%02x%02x", mac[3], mac[4], mac[5]);
         device.setUniqueId(mac, sizeof(mac));
         device.setName(uniqueID);
         device.setSoftwareVersion(VERSION);


### PR DESCRIPTION
…8+1 string

I'm a little bit rusty in developing and github but maybe this is useful. I've spotted a possible out of bounds access in macStr. Not sure if it is necessary though since 3 x mac are 18 characters which should fit.