### PR TITLE
Allow to set lowest brightness via menu

### DIFF
--- a/src/MenuManager.cpp
+++ b/src/MenuManager.cpp
@@ -117,6 +117,22 @@ MenuManager_ &MenuManager_::getInstance()
 // Initialize the global shared instance
 MenuManager_ &MenuManager = MenuManager.getInstance();
 
+int convertBRIPercentTo8Bit(int brightness_percent)
+{
+    int brightness;
+    if (brightness_percent <= 10) {
+        // Map 10 % or lower 1:1 to 0:255 range. Reasons:
+        // * 1% would be mapped to 2 so lowest value would be inaccessible.
+        // * Small changes in lower brightness are perceived by humans
+        //   as big changes, so it makes sense to give higher
+        //   "resolution" here.
+        brightness = brightness_percent;
+    } else {
+        brightness = map(brightness_percent, 0, 100, 0, 255);
+    }
+    return brightness;
+}
+
 String MenuManager_::menutext()
 {
     time_t now = time(nullptr);
@@ -216,7 +232,7 @@ void MenuManager_::rightButton()
         if (!AUTO_BRIGHTNESS)
         {
             BRIGHTNESS_PERCENT = (BRIGHTNESS_PERCENT % 100) + 1;
-            BRIGHTNESS = map(BRIGHTNESS_PERCENT, 0, 100, 0, 255);
+            BRIGHTNESS = convertBRIPercentTo8Bit(BRIGHTNESS_PERCENT);
             DisplayManager.setBrightness(BRIGHTNESS);
         }
         break;
@@ -277,7 +293,7 @@ void MenuManager_::leftButton()
         if (!AUTO_BRIGHTNESS)
         {
             BRIGHTNESS_PERCENT = (BRIGHTNESS_PERCENT == 1) ? 100 : BRIGHTNESS_PERCENT - 1;
-            BRIGHTNESS = map(BRIGHTNESS_PERCENT, 0, 100, 0, 255);
+            BRIGHTNESS = convertBRIPercentTo8Bit(BRIGHTNESS_PERCENT);
             DisplayManager.setBrightness(BRIGHTNESS);
         }
         break;
@@ -335,7 +351,12 @@ void MenuManager_::selectButton()
         switch (menuIndex)
         {
         case 0:
-            BRIGHTNESS_PERCENT = map(BRIGHTNESS, 0, 255, 0, 100);
+            // reverse of convertBRIPercentTo8Bit.
+            if (BRIGHTNESS <= 10) {
+                BRIGHTNESS_PERCENT = BRIGHTNESS;
+            } else {
+                BRIGHTNESS_PERCENT = map(BRIGHTNESS, 0, 255, 0, 100);
+            }
             currentState = BrightnessMenu;
             break;
         case 1:
@@ -387,7 +408,7 @@ void MenuManager_::selectButton()
         AUTO_BRIGHTNESS = !AUTO_BRIGHTNESS;
         if (!AUTO_BRIGHTNESS)
         {
-            BRIGHTNESS = map(BRIGHTNESS_PERCENT, 0, 100, 0, 255);
+            BRIGHTNESS = convertBRIPercentTo8Bit(BRIGHTNESS_PERCENT);
             DisplayManager.setBrightness(BRIGHTNESS);
         }
         break;


### PR DESCRIPTION
Via the API, this is already possible. My use case: bedroom and read the time in the dark. Have been testing that with 1/255 brightness Ulanzi clock for a couple of nights. 1/255 is low enough to not light up the bedroom in any way.