### PR TITLE
Lock EasyButton version due to regression breaking build

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -21,7 +21,7 @@ monitor_filters = esp32_exception_decoder
 lib_deps = 
 	adafruit/Adafruit SHT31 Library@^2.2.0
 	bblanchon/ArduinoJson@^6.20.0
-	evert-arias/EasyButton@^2.0.1
+	evert-arias/EasyButton@2.0.1
 	fastled/FastLED@^3.5.0
 	marcmerlin/FastLED NeoMatrix@^1.2
 	knolleary/PubSubClient@^2.8


### PR DESCRIPTION
Two weeks ago, EasyButton added a new uncommitted header which is breaking awtrix builds.

`.pio/libdeps/ulanzi/EasyButton/src/EasyButtonTouch.h:14:10: fatal error: Filter.h: No such file or directory`

Because this release was pushed as 2.0.3 and the PIO dep was set to @^2.0.1, awtrix-light is pulling the new version when building because semver. This means any full clean builds or builds from a fresh checkout will fail.

Until this is fixed upstream, hard pinning the dep to the previous 2.0.1 allows building.

Upstream issue: https://github.com/evert-arias/EasyButton/issues/83