### PR TITLE
fix calculation of automatic brightness control

### DIFF
--- a/src/PeripheryManager.cpp
+++ b/src/PeripheryManager.cpp
@@ -464,7 +464,7 @@ void PeripheryManager_::tick()
         CURRENT_LUX = (roundf(photocell.getSmoothedLux() * 1000) / 1000);
         if (AUTO_BRIGHTNESS && !MATRIX_OFF)
         {
-            brightnessPercent = sampleAverage / 4095.0 * 100.0;
+            brightnessPercent = sampleAverage / 1023.0 * 100.0;
             BRIGHTNESS = map(brightnessPercent, 0, 100, MIN_BRIGHTNESS, MAX_BRIGHTNESS);
             DisplayManager.setBrightness(BRIGHTNESS);
         }


### PR DESCRIPTION
Match calculation of automatic brightness control to real bit width of the LDR sensor signal; sensor signal is 10bit, so 100% brightness is reached at 1023.0 - not 4095.0

The issue has been discussed before [here](https://discord.com/channels/546407049148366859/1155195170753609868) in Discord. 
So far it is tested on a DIY hardware only, so somebody should check it on a Ulanzi version. You will notice, the display is much brighter now. Probably this is little too much for a less capable hardware in terms of generated heat, so maybe the default value of MAX_BRIGHTNESS needs to be decreased a little bit as well.

