### PR TITLE
Revert fix for a known typo

### DIFF
--- a/src/ArtnetWifi.h
+++ b/src/ArtnetWifi.h
@@ -106,7 +106,7 @@ public:
   }
 
   [[deprecated]]
-  inline void setPhysical(uint8_t port)
+  inline void setPhisical(uint8_t port)
   {
     setPhysical(port);
   }


### PR DESCRIPTION
CI fails in this line.
```
src/ArtnetWifi.h:109:15: error: 'void ArtnetWifi::setPhysical(uint8_t)' cannot be overloaded with 'void ArtnetWifi::setPhysical(uint8_t)'
```