### PR TITLE
Updated wording to make ".txt" extension mandatory

### DIFF
--- a/docs/sounds.md
+++ b/docs/sounds.md
@@ -3,9 +3,11 @@
 
 Optionally, you can play a sound via the integrated buzzer.  
 To do this, go to the file manager in the web interface and create a new text file in the "MELODIES" folder.
-Name it whatever you like, e.g. "alarm.txt". Inside the file, place a melody in RTTTL format.
-You can find many melodies on the internet. 
- 
+Name it whatever you like but use ".txt" extension, e.g. "alarm.txt". Inside the file, place a melody in RTTTL format.
+When using the sound file anywhere, omit file extension.
+
+You can find many melodies on the internet.
+
 For example, here:  
 https://www.laub-home.de/wiki/RTTTL_Songs
 


### PR DESCRIPTION
Updated wording to make ".txt" extension mandatory. Earlier it didn't sound correct at least for non-English speakers.