### PR TITLE
Added CORS preflight OPTIONS support

### DIFF
--- a/lib/webserver/esp-fs-webserver.cpp
+++ b/lib/webserver/esp-fs-webserver.cpp
@@ -641,7 +641,11 @@ void FSWebServer::replyToCLient(int msg_type = 0, const char *msg = "")
         webserver->send(200, FPSTR(TEXT_PLAIN), msg);
         break;
     case NOT_FOUND:
-        webserver->send(404, FPSTR(TEXT_PLAIN), msg);
+        if (webserver->method() == HTTP_OPTIONS) {
+            webserver->send(204); // preflight CORS OPTIONS requests should return OK status 
+        } else {
+            webserver->send(404, FPSTR(TEXT_PLAIN), msg);
+        }
         break;
     case BAD_REQUEST:
         webserver->send(400, FPSTR(TEXT_PLAIN), msg);


### PR DESCRIPTION
Reply 204 instead of 404 for OPTIONS requests. This change makes it possible to use the REST API from a browser without using a proxy to forward the requests. I see that enableCORS is already added in esp-fs-webserver.cpp, but I don't see how it would work without handling OPTIONS requests. 

Could probably only have been added to the required routes.