### PR TITLE
Send LDR and BATT raw values through standard median and mean filters…

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -32,6 +32,8 @@ lib_deps =
 	marcmerlin/FastLED NeoMatrix@^1.2
 	knolleary/PubSubClient@^2.8
 	densaugeo/base64@^1.4.0
+    luisllamasbinaburo/MedianFilterLib@^1.0.0
+	luisllamasbinaburo/MeanFilterLib@^1.0.0
 
 [env:awtrix2_upgrade]
 platform = espressif32
@@ -60,6 +62,8 @@ lib_deps =
 	marcmerlin/FastLED NeoMatrix@^1.2
 	knolleary/PubSubClient@^2.8
 	densaugeo/base64@^1.4.0
+    luisllamasbinaburo/MedianFilterLib@^1.0.0
+	luisllamasbinaburo/MeanFilterLib@^1.0.0
 
 [env:ESP32_S3]
 platform = espressif32
@@ -78,3 +82,5 @@ lib_deps =
 	marcmerlin/FastLED NeoMatrix@^1.2
 	knolleary/PubSubClient@^2.8
 	densaugeo/base64@^1.4.0
+    luisllamasbinaburo/MedianFilterLib@^1.0.0
+	luisllamasbinaburo/MeanFilterLib@^1.0.0

--- a/platformio.ini
+++ b/platformio.ini
@@ -8,13 +8,28 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
+[platformio]
+default_envs = ulanzi
+
+[env]
+framework = arduino
+board_build.f_cpu = 240000000L
+upload_speed = 921600
+monitor_speed = 115200
+monitor_filters = esp32_exception_decoder
+lib_deps = 
+	bblanchon/ArduinoJson@^6.20.0
+	evert-arias/EasyButton@2.0.1
+	fastled/FastLED@^3.6.0
+	marcmerlin/FastLED NeoMatrix@^1.2
+	knolleary/PubSubClient@^2.8
+	densaugeo/base64@^1.4.0
+    luisllamasbinaburo/MedianFilterLib@^1.0.0
+	luisllamasbinaburo/MeanFilterLib@^1.0.0
+
 [env:ulanzi]
 platform = espressif32@6.3.0
 board = esp32dev
-upload_speed = 921600
-framework = arduino
-board_build.f_cpu = 240000000L
-monitor_speed = 115200
 build_flags = 
 	-DULANZI
 	-DMQTT_MAX_PACKET_SIZE=8192
@@ -23,25 +38,13 @@ build_flags =
 	-Wno-attributes
 	-Os
 	-fno-exceptions
-monitor_filters = esp32_exception_decoder
 lib_deps = 
+    ${env.lib_deps}
 	adafruit/Adafruit SHT31 Library@^2.2.0
-	bblanchon/ArduinoJson@^6.20.0
-	evert-arias/EasyButton@2.0.1
-	fastled/FastLED@^3.6.0
-	marcmerlin/FastLED NeoMatrix@^1.2
-	knolleary/PubSubClient@^2.8
-	densaugeo/base64@^1.4.0
-    luisllamasbinaburo/MedianFilterLib@^1.0.0
-	luisllamasbinaburo/MeanFilterLib@^1.0.0
 
 [env:awtrix2_upgrade]
 platform = espressif32
 board = wemos_d1_mini32
-upload_speed = 921600
-board_build.f_cpu = 240000000L
-framework = arduino
-monitor_speed = 115200
 build_flags = 
 	-Dawtrix2_upgrade
 	-DMQTT_MAX_PACKET_SIZE=8192
@@ -50,37 +53,19 @@ build_flags =
 	-Wno-attributes
 	-Os
 	-fno-exceptions
-monitor_filters = esp32_exception_decoder
 lib_deps = 
+    ${env.lib_deps}
 	adafruit/Adafruit BME280 Library@^2.2.2
 	adafruit/Adafruit BMP280 Library@^2.6.8
 	adafruit/Adafruit HTU21DF Library@^1.0.5
 	plerup/EspSoftwareSerial@^8.0.1
-	bblanchon/ArduinoJson@^6.20.0
-	evert-arias/EasyButton@2.0.1
-	fastled/FastLED@^3.5.0
-	marcmerlin/FastLED NeoMatrix@^1.2
-	knolleary/PubSubClient@^2.8
-	densaugeo/base64@^1.4.0
-    luisllamasbinaburo/MedianFilterLib@^1.0.0
-	luisllamasbinaburo/MeanFilterLib@^1.0.0
 
 [env:ESP32_S3]
 platform = espressif32
 board = esp32-s3-devkitc-1-n16r8v
-upload_speed = 921600
-board_build.f_cpu = 240000000L
-framework = arduino
-monitor_speed = 115200
-build_flags = -DESP32_S3 -D MQTT_MAX_PACKET_SIZE=8192
-monitor_filters = esp32_exception_decoder
+build_flags =
+    -DESP32_S3 
+	-D MQTT_MAX_PACKET_SIZE=8192
 lib_deps = 
+    ${env.lib_deps}
 	adafruit/Adafruit SHT31 Library@^2.2.0
-	bblanchon/ArduinoJson@^6.20.0
-	evert-arias/EasyButton@2.0.1
-	fastled/FastLED@^3.6.0
-	marcmerlin/FastLED NeoMatrix@^1.2
-	knolleary/PubSubClient@^2.8
-	densaugeo/base64@^1.4.0
-    luisllamasbinaburo/MedianFilterLib@^1.0.0
-	luisllamasbinaburo/MeanFilterLib@^1.0.0

--- a/src/PeripheryManager.cpp
+++ b/src/PeripheryManager.cpp
@@ -501,7 +501,7 @@ void PeripheryManager_::tick()
         uint16_t LDRVALUE = analogRead(LDR_PIN);
 
         // Send LDR values through median filter to get rid of the remaining spikes and then calculate the average
-        LDR_RAW = medianFilterLDR.AddValue(medianFilterLDR.AddValue(LDRVALUE));
+        LDR_RAW = meanFilterLDR.AddValue(medianFilterLDR.AddValue(LDRVALUE));
         CURRENT_LUX = (roundf(photocell.getSmoothedLux() * 1000) / 1000);
         if (AUTO_BRIGHTNESS && !MATRIX_OFF)
         {

--- a/src/PeripheryManager.h
+++ b/src/PeripheryManager.h
@@ -16,16 +16,6 @@ class PeripheryManager_
 {
 private:
     PeripheryManager_() = default;
-#ifdef ULANZI
-    const int BatReadings = 10;
-    uint16_t TotalBatReadings[10];
-#endif
-    int readIndex = 0;
-    uint16_t total = 0;
-    uint16_t average = 0;
-    const int LDRReadings = 30;
-    uint16_t TotalLDRReadings[30];
-    int sampleIndex = 0;
     unsigned long previousMillis = 0;
     const unsigned long interval = 1000;
 


### PR DESCRIPTION
… to get rid of spikes.

Remove obsolete (and even duplicate) declarations

The attached image shows the before/after behaviour for the battery status. It is not that obvious with the LDR values, because there already was an average filter. But this filter had a very inefficient O(n²) implementation, so I used the same filtering for battery and LDR. A window size of seven of seven is sufficient for the median. The window size for the average could be increased if necessary to smoothen it out even more.

![grafik](https://github.com/Blueforcer/awtrix-light/assets/3872576/136cb063-f50e-4321-ac27-29ccd408bf5f)

OK, it looks like GH made one PR out of my two commits, even though I created the PR before the second commit. 
Concerning the pio.ini cleanup: The awtrux2_upgrade and the ESP32_S3 configurations didn't build before, because of include/definition errors, so I haven't introduced them with the cleanup. But I'm not sure how to fix them.
