### PR TITLE
Option to disable all battery related stuff (has_battery flag for dev.json)

### DIFF
--- a/docs/dev.md
+++ b/docs/dev.md
@@ -40,6 +40,7 @@ The JSON object has the following properties:
 | `new_year` | boolean | Displays fireworks and plays a jingle at newyear. | false |
 | `swap_buttons` | boolean | Swaps the left and right hardware button. | false |
 | `ldr_on_ground` | boolean | Sets the LDR configuration to LDR-on-ground. | false |
+| `has_battery` | boolean | Disables all battery related sensors and mqtt-stats if set to false | true |
 
 
 #### Example:

--- a/src/DisplayManager.cpp
+++ b/src/DisplayManager.cpp
@@ -1109,7 +1109,10 @@ void DisplayManager_::loadNativeApps()
     updateApp("Humidity", HumApp, SHOW_HUM, 3);
   }
 #ifdef ULANZI
-  updateApp("Battery", BatApp, SHOW_BAT, 4);
+  if (HAS_BATTERY)
+  {
+    updateApp("Battery", BatApp, SHOW_BAT, 4);
+  }
 #endif
 
   ui->setApps(Apps);
@@ -1545,7 +1548,7 @@ std::pair<String, AppCallback> getNativeAppByName(const String &appName)
     return std::make_pair("Humidity", HumApp);
   }
 #ifdef ULANZI
-  else if (appName == "Battery")
+  else if (appName == "Battery" && HAS_BATTERY)
   {
     return std::make_pair("Battery", BatApp);
   }
@@ -1641,8 +1644,10 @@ String DisplayManager_::getStats()
 #ifdef awtrix2_upgrade
   doc[F("type")] = 1;
 #else
-  doc[BatKey] = BATTERY_PERCENT;
-  doc[BatRawKey] = BATTERY_RAW;
+  if (HAS_BATTERY){
+    doc[BatKey] = BATTERY_PERCENT;
+    doc[BatRawKey] = BATTERY_RAW;
+  }
   doc[F("type")] = 0;
 #endif
   doc[LuxKey] = static_cast<int>(CURRENT_LUX);

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -230,6 +230,11 @@ void loadDevSettings()
             }
         }
 
+        if (doc.containsKey("has_battery"))
+        {
+            HAS_BATTERY = doc["has_battery"].as<bool>();
+        }
+
         file.close();
     }
     else
@@ -463,3 +468,4 @@ int WEB_PORT = 80;
 OverlayEffect GLOBAL_OVERLAY = NONE;
 String HOSTNAME = "";
 bool BUZ_VOL = false;
+bool HAS_BATTERY = true;

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -150,4 +150,5 @@ extern OverlayEffect GLOBAL_OVERLAY;
 extern String HOSTNAME;
 extern int WEB_PORT;
 extern bool BUZ_VOL;
+extern bool HAS_BATTERY;
 #endif // Globals_H

--- a/src/MQTTManager.cpp
+++ b/src/MQTTManager.cpp
@@ -374,6 +374,15 @@ String MQTTManager_::getValueForTopic(const String &topic)
     }
 }
 
+char* getMacString()
+{
+    uint8_t mac[6];
+    WiFi.macAddress(mac);
+    static char macStr[7];
+    snprintf(macStr, 7, "%02x%02x%02x", mac[3], mac[4], mac[5]);
+    return macStr;
+}
+
 void onMqttConnected()
 {
 
@@ -432,6 +441,31 @@ void onMqttConnected()
     {
         MQTTManager.publish("stats/device", "online");
     }
+
+    #ifdef ULANZI
+    if (HA_DISCOVERY && !HAS_BATTERY)
+    {   
+        sprintf(batID, HAbatID, getMacString());
+        if (DEBUG_MODE)
+            DEBUG_PRINTLN(F("Removing old battery sensor from HA"));
+        char topic[100];
+        strcpy(topic, "homeassistant/sensor/");
+        strcat(topic, device.getUniqueId());
+        strcat(topic, "/");
+        strcat(topic, batID);
+        strcat(topic, "/config");
+        mqtt.publish(topic, "", true); // remove battery sensor from HA
+
+        strcpy(topic, MQTT_PREFIX.c_str());
+        strcat(topic, "/");
+        strcat(topic, device.getUniqueId());
+        strcat(topic, "/");
+        strcat(topic, batID);
+        strcat(topic, "/stat_t");
+        mqtt.publish(topic, "", true); // remove battery sensor from mqtt
+    }
+    #endif
+
     connected = true;
 }
 
@@ -495,8 +529,11 @@ void MQTTManager_::sendStats()
     {
         char buffer[8];
 #ifndef awtrix2_upgrade
-        snprintf(buffer, 5, "%d", BATTERY_PERCENT);
-        battery->setValue(buffer);
+        if (HAS_BATTERY)
+        {
+            snprintf(buffer, 5, "%d", BATTERY_PERCENT);
+            battery->setValue(buffer);
+        }
 #endif
         if (SENSOR_READING)
         {
@@ -546,8 +583,7 @@ void MQTTManager_::setup()
         mqtt.setDataPrefix(MQTT_PREFIX.c_str());
         uint8_t mac[6];
         WiFi.macAddress(mac);
-        char macStr[7];
-        snprintf(macStr, 7, "%02x%02x%02x", mac[3], mac[4], mac[5]);
+        char* macStr = getMacString();
         device.setUniqueId(mac, sizeof(mac));
         device.setName(HOSTNAME.c_str());
         device.setSoftwareVersion(VERSION);
@@ -675,13 +711,15 @@ void MQTTManager_::setup()
         humidity->setUnitOfMeasurement(HAhumUnit);
 
 #ifdef ULANZI
-        sprintf(batID, HAbatID, macStr);
-        battery = new HASensor(batID);
-        battery->setIcon(HAbatIcon);
-        battery->setName(HAbatName);
-        battery->setDeviceClass(HAbatClass);
-        battery->setUnitOfMeasurement(HAbatUnit);
-
+        if (HAS_BATTERY)
+        {
+            sprintf(batID, HAbatID, macStr);
+            battery = new HASensor(batID);
+            battery->setIcon(HAbatIcon);
+            battery->setName(HAbatName);
+            battery->setDeviceClass(HAbatClass);
+            battery->setUnitOfMeasurement(HAbatUnit);
+        }
 #endif
         sprintf(luxID, HAluxID, macStr);
         illuminance = new HASensor(luxID);

--- a/src/MenuManager.cpp
+++ b/src/MenuManager.cpp
@@ -73,7 +73,7 @@ int8_t dateFormatIndex;
 uint8_t dateFormatCount = 9;
 
 int8_t appsIndex;
-uint8_t appsCount = 5;
+uint8_t defaultAppsCount = 5;
 
 MenuState currentState = MainMenu;
 
@@ -125,6 +125,15 @@ int convertBRIPercentTo8Bit(int brightness_percent)
     return brightness;
 }
 
+uint8_t getAppsCount()
+{
+    uint8_t appsCount = defaultAppsCount;
+    if (!HAS_BATTERY){
+            appsCount -= 1;
+    }
+    return appsCount;
+}
+
 String MenuManager_::menutext()
 {
     char t[20];
@@ -173,7 +182,7 @@ String MenuManager_::menutext()
     case TempMenu:
         return IS_CELSIUS ? "°C" : "°F";
     case Appmenu:
-        DisplayManager.drawMenuIndicator(appsIndex, appsCount, 0xFBC000);
+        DisplayManager.drawMenuIndicator(appsIndex, getAppsCount(), 0xFBC000);
         switch (appsIndex)
         {
         case 0:
@@ -189,7 +198,8 @@ String MenuManager_::menutext()
             DisplayManager.drawBMP(0, 0, icon_2075, 8, 8);
             return SHOW_HUM ? "ON" : "OFF";
 #ifndef awtrix2_upgrade
-        case 4:
+        case 4: 
+            // TODO: Very Hacky! Its better to init the apps with help of an array so we dont need to use index here. With this approach we could also do better conditional app rendering.
             DisplayManager.drawBMP(0, 0, icon_1486, 8, 8);
             return SHOW_BAT ? "ON" : "OFF";
 #endif
@@ -248,7 +258,7 @@ void MenuManager_::rightButton()
         dateFormatIndex = (dateFormatIndex + 1) % dateFormatCount;
         break;
     case Appmenu:
-        appsIndex = (appsIndex + 1) % appsCount;
+        appsIndex = (appsIndex + 1) % getAppsCount();
         break;
     case WeekdayMenu:
         START_ON_MONDAY = !START_ON_MONDAY;
@@ -310,7 +320,7 @@ void MenuManager_::leftButton()
         dateFormatIndex = (dateFormatIndex == 0) ? dateFormatCount - 1 : dateFormatIndex - 1;
         break;
     case Appmenu:
-        appsIndex = (appsIndex == 0) ? appsCount - 1 : appsIndex - 1;
+        appsIndex = (appsIndex == 0) ? getAppsCount() - 1 : appsIndex - 1;
         break;
     case WeekdayMenu:
         START_ON_MONDAY = !START_ON_MONDAY;

--- a/src/PeripheryManager.cpp
+++ b/src/PeripheryManager.cpp
@@ -485,15 +485,20 @@ void PeripheryManager_::tick()
     {
         previousMillis_BatTempHum = currentMillis_BatTempHum;
 #ifndef awtrix2_upgrade
-        uint16_t ADCVALUE = analogRead(BATTERY_PIN);
-        // Discard values that are totally out of range, especially the first value read after a reboot.
-        // Meaningful values for an Ulanzi clock are in the range 400..700
-        if ((ADCVALUE > 100) && (ADCVALUE < 1000))
+        if (HAS_BATTERY)
         {
-            // Send ADC values through median filter to get rid of the remaining spikes and then calculate the average
-            BATTERY_RAW = meanFilterBatt.AddValue(medianFilterBatt.AddValue(ADCVALUE));
-            BATTERY_PERCENT = max(min((int)map(BATTERY_RAW, MIN_BATTERY, MAX_BATTERY, 0, 100), 100), 0);
-            SENSORS_STABLE = true;
+            uint16_t ADCVALUE = analogRead(BATTERY_PIN);
+            // Discard values that are totally out of range, especially the first value read after a reboot.
+            // Meaningful values for an Ulanzi clock are in the range 400..700
+            if ((ADCVALUE > 100) && (ADCVALUE < 1000))
+            {
+                // Send ADC values through median filter to get rid of the remaining spikes and then calculate the average
+                BATTERY_RAW = meanFilterBatt.AddValue(medianFilterBatt.AddValue(ADCVALUE));
+                BATTERY_PERCENT = max(min((int)map(BATTERY_RAW, MIN_BATTERY, MAX_BATTERY, 0, 100), 100), 0);
+                SENSORS_STABLE = true;
+            }
+        } else {
+            SENSORS_STABLE = true; // Battery not present
         }
 #else
         SENSORS_STABLE = true;


### PR DESCRIPTION
Adds a new config flag (has_battery)
Setting has_battery to false removes all battery related stuff like:
* bat and bat_raw from stats response (api /mqtt)
* HA battery sensor (will be removed, if present before)
* Internal battery app will not be loaded and cant be enabled from menu or api. 