### PR TITLE
Skip AP with middle button to show custom apps even when offline, use 'show_wifi_indicator' in dev.json to hide the blinking red dot with no WiFi

### DIFF
--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -166,6 +166,11 @@ void loadDevSettings()
             BUZ_VOL = doc["buzzer_volume"].as<bool>();
         }
 
+        if (doc.containsKey("show_wifi_indicator"))
+        {
+            SHOW_WIFI_INDICATOR = doc["show_wifi_indicator"].as<bool>();
+        }
+
         if (doc.containsKey("web_port"))
         {
             WEB_PORT = doc["web_port"];
@@ -463,3 +468,4 @@ int WEB_PORT = 80;
 OverlayEffect GLOBAL_OVERLAY = NONE;
 String HOSTNAME = "";
 bool BUZ_VOL = false;
+bool SHOW_WIFI_INDICATOR = true;

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -150,4 +150,5 @@ extern OverlayEffect GLOBAL_OVERLAY;
 extern String HOSTNAME;
 extern int WEB_PORT;
 extern bool BUZ_VOL;
+extern bool SHOW_WIFI_INDICATOR;
 #endif // Globals_H

--- a/src/Overlays.cpp
+++ b/src/Overlays.cpp
@@ -6,13 +6,14 @@
 #include <WiFi.h>
 #include "effects.h"
 #include "MQTTManager.h"
+#include "Globals.h"
 
 std::vector<Notification> notifications;
 bool notifyFlag = false;
 
 void StatusOverlay(FastLED_NeoMatrix *matrix, MatrixDisplayUiState *state, GifPlayer *gifPlayer)
 {
-    if (!WiFi.isConnected())
+    if (SHOW_WIFI_INDICATOR && !WiFi.isConnected())
     {
         matrix->drawPixel(0, 0, fadeColor(0xFF0000, 2000));
     }

--- a/src/PeripheryManager.cpp
+++ b/src/PeripheryManager.cpp
@@ -169,6 +169,23 @@ void right_button_pressed()
 
 void select_button_pressed()
 {
+    // Exit AP mode on button press
+    if (AP_MODE)
+    {
+        if (DFPLAYER_ACTIVE)
+            PeripheryManager.playFromFile(DFMINI_MP3_CLICK);
+
+        AP_MODE = false;
+
+        // Show brief transition message
+        DisplayManager.HSVtext(4, 6, "EXIT AP", true, 0);
+        delay(500);
+
+        if (DEBUG_MODE)
+            DEBUG_PRINTLN(F("Exiting AP mode via button press"));
+        return;
+    }
+
     if (!BLOCK_NAVIGATION)
     {
         if (DFPLAYER_ACTIVE)

--- a/src/ServerManager.cpp
+++ b/src/ServerManager.cpp
@@ -222,6 +222,7 @@ void ServerManager_::setup()
     mws.setAuth(AUTH_USER, AUTH_PASS);
     if (isConnected)
     {
+        mws.clearOptions(); // Clear any existing options to prevent duplicates
         mws.addOptionBox("Network");
         mws.addOption("Static IP", NET_STATIC);
         mws.addOption("Local IP", NET_IP);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -73,11 +73,14 @@ void setup()
   delay(500);
   xTaskCreatePinnedToCore(BootAnimation, "Task", 10000, NULL, 1, &taskHandle, 0);
   ServerManager.setup();
+
+  // Load apps regardless of WiFi status
+  DisplayManager.loadNativeApps();
+  DisplayManager.loadCustomApps();
+
   if (ServerManager.isConnected)
   {
-    // timer_init();
-    DisplayManager.loadNativeApps();
-    DisplayManager.loadCustomApps();
+    // WiFi-dependent services only
     UpdateManager.setup();
     DisplayManager.startArtnet();
     StopTask = true;
@@ -96,14 +99,14 @@ void setup()
       x -= 0.18;
     }
 
-    
+
       if (MQTT_HOST != "")
       {
         DisplayManager.HSVtext(4, 6, "MQTT...", true, 0);
         MQTTManager.setup();
         MQTTManager.tick();
       }
-    
+
   }
   else
   {


### PR DESCRIPTION
Changes Made                                                                                                                                                             
                                                                                                                                                                           
  1. Added configurable WiFi indicator display (PR-ready feature)                                                                                                          
                                                                                                                                                                           
  Files modified:                                                                                                                                                          
  - src/Globals.h - Added SHOW_WIFI_INDICATOR global variable declaration                                                                                                  
  - src/Globals.cpp - Added loading logic for show_wifi_indicator from dev.json and initialized default value to true                                                      
  - src/Overlays.cpp - Added #include "Globals.h" and wrapped WiFi indicator drawing in conditional check                                                                  
                                                                                                                                                                           
  What it does:                                                                                                                                                            
  - Added a new configuration option to control whether the blinking red dot (WiFi disconnected indicator) appears at position (0,0) on the matrix                         
  - The setting is controlled via the /dev.json file using the key "show_wifi_indicator": true/false                                                                       
  - Defaults to true (showing the indicator) for backward compatibility                                                                                                    
  - The yellow MQTT indicator at (0,7) remains unchanged                                                                                                                   
                                                                                                                                                                           
  Usage:                                                                                                                                                                   
  {                                                                                                                                                                        
    "show_wifi_indicator": false                                                                                                                                           
  }                                                                                                                                                                        
                                                                                                                                                                           
  2. Fixed duplicate menu items in web interface (Bug fix)                                                                                                                 
                                                                                                                                                                           
  Files modified:                                                                                                                                                          
  - src/ServerManager.cpp - Added mws.clearOptions() call before adding option boxes                                                                                       
                                                                                                                                                                           
  What it does:                                                                                                                                                            
  - Fixed a bug where menu items (Network, MQTT, Time, Icons, Auth) appeared twice in the web interface navigation                                                         
  - The issue was caused by accumulated duplicate entries in /DoNotTouch.json over time                                                                                    
  - Now clears the options file on every boot before regenerating menu items, ensuring a clean state                                                                       
                                                                                                                                                                           
  Before: Menu showed duplicate navigation items                                                                                                                           
  After: Clean, single set of navigation items                                                                                                                             
                                                                                                                                                                           
  3. Code refactoring in main.cpp (Already present in diff)                                                                                                                
                                                                                                                                                                           
  Files modified:                                                                                                                                                          
  - src/main.cpp                                                                                                                                                           
                                                                                                                                                                           
  What it does:                                                                                                                                                            
  - Moved DisplayManager.loadNativeApps() and DisplayManager.loadCustomApps() outside the WiFi-connected check                                                             
  - Apps now load regardless of WiFi status, improving offline functionality                                                                                               
  - Added clarifying comments for WiFi-dependent vs WiFi-independent services                                                                                              
                                                                                                                                                                           
  ---                                                                                                                                                                      
  Suggested PR Title                                                                                                                                                       
                                                                                                                                                                           
  "Add configurable WiFi indicator and fix duplicate web menu items"                                                                                                       
                                                                                                                                                                           
  Suggested PR Description                                                                                                                                                 
                                                                                                                                                                           
  ### Features                                                                                                                                                             
  - Added `show_wifi_indicator` configuration option in `dev.json` to control display of WiFi disconnection indicator (red blinking dot at top-left)                       
    - Defaults to `true` for backward compatibility                                                                                                                        
    - Set to `false` to hide the indicator                                                                                                                                 
                                                                                                                                                                           
  ### Bug Fixes                                                                                                                                                            
  - Fixed duplicate menu items appearing in web interface navigation                                                                                                       
    - Menu items (Network, MQTT, Time, Icons, Auth) were appearing twice                                                                                                   
    - Now properly clears options on boot to prevent accumulation                                                                                                          
                                                                                                                                                                           
  ### Improvements                                                                                                                                                         
  - Apps now load regardless of WiFi connection status for better offline functionality                                                                                    
                                                                                               