### PR TITLE
Add 8KB body size limit to JSON POST endpoints to prevent heap exhaustion

### DIFF
--- a/src/ServerManager.cpp
+++ b/src/ServerManager.cpp
@@ -69,6 +69,11 @@ void saveHandler()
     webRequest->send(200);
 }
 
+static bool isBodyOversized()
+{
+    return mws.webserver->arg("plain").length() > 8192;
+}
+
 void addHandler()
 {
 
@@ -99,6 +104,7 @@ void addHandler()
 
     mws.addHandler("/api/moodlight", HTTP_POST, []()
                    {
+                    if (isBodyOversized()) { mws.webserver->send(400,F("text/plain"),F("BadRequest")); return; }
                     if (DisplayManager.moodlight(mws.webserver->arg("plain").c_str()))
                     {
                         mws.webserver->send(200, F(F("text/plain")), F("OK"));
@@ -109,6 +115,7 @@ void addHandler()
                     } });
     mws.addHandler("/api/notify", HTTP_POST, []()
                    {
+                       if (isBodyOversized()) { mws.webserver->send(400,F("text/plain"),F("BadRequest")); return; }
                        if (DisplayManager.generateNotification(1,mws.webserver->arg("plain").c_str()))
                        {
                         mws.webserver->send(200, F("text/plain"), F("OK"));
@@ -136,7 +143,8 @@ void addHandler()
     mws.addHandler("/api/notify/dismiss", HTTP_ANY, []()
                    { DisplayManager.dismissNotify(); mws.webserver->send(200,F("text/plain"),F("OK")); });
     mws.addHandler("/api/apps", HTTP_POST, []()
-                   { DisplayManager.updateAppVector(mws.webserver->arg("plain").c_str()); mws.webserver->send(200,F("text/plain"),F("OK")); });
+                   { if (isBodyOversized()) { mws.webserver->send(400,F("text/plain"),F("BadRequest")); return; }
+                     DisplayManager.updateAppVector(mws.webserver->arg("plain").c_str()); mws.webserver->send(200,F("text/plain"),F("OK")); });
     mws.addHandler(
         "/api/switch", HTTP_POST, []()
         {
@@ -151,17 +159,20 @@ void addHandler()
     mws.addHandler("/api/apps", HTTP_GET, []()
                    { mws.webserver->send_P(200, "application/json", DisplayManager.getAppsWithIcon().c_str()); });
     mws.addHandler("/api/settings", HTTP_POST, []()
-                   { DisplayManager.setNewSettings(mws.webserver->arg("plain").c_str()); mws.webserver->send(200,F("text/plain"),F("OK")); });
+                   { if (isBodyOversized()) { mws.webserver->send(400,F("text/plain"),F("BadRequest")); return; }
+                     DisplayManager.setNewSettings(mws.webserver->arg("plain").c_str()); mws.webserver->send(200,F("text/plain"),F("OK")); });
     mws.addHandler("/api/erase", HTTP_ANY, []()
                    { ServerManager.erase();  mws.webserver->send(200,F("text/plain"),F("OK"));delay(200); ESP.restart(); });
     mws.addHandler("/api/resetSettings", HTTP_ANY, []()
                    { formatSettings();   mws.webserver->send(200,F("text/plain"),F("OK"));delay(200); ESP.restart(); });
     mws.addHandler("/api/reorder", HTTP_POST, []()
-                   { DisplayManager.reorderApps(mws.webserver->arg("plain").c_str()); mws.webserver->send(200,F("text/plain"),F("OK")); });
+                   { if (isBodyOversized()) { mws.webserver->send(400,F("text/plain"),F("BadRequest")); return; }
+                     DisplayManager.reorderApps(mws.webserver->arg("plain").c_str()); mws.webserver->send(200,F("text/plain"),F("OK")); });
     mws.addHandler("/api/settings", HTTP_GET, []()
                    { mws.webserver->send_P(200, "application/json", DisplayManager.getSettings().c_str()); });
     mws.addHandler("/api/custom", HTTP_POST, []()
-                   { 
+                   {
+                    if (isBodyOversized()) { mws.webserver->send(400,F("text/plain"),F("BadRequest")); return; }
                     if (DisplayManager.parseCustomPage(mws.webserver->arg("name"),mws.webserver->arg("plain").c_str(),false)){
                         mws.webserver->send(200,F("text/plain"),F("OK")); 
                     }else{
@@ -172,21 +183,24 @@ void addHandler()
     mws.addHandler("/api/screen", HTTP_GET, []()
                    { mws.webserver->send_P(200, "application/json", DisplayManager.ledsAsJson().c_str()); });
     mws.addHandler("/api/indicator1", HTTP_POST, []()
-                   { 
+                   {
+                    if (isBodyOversized()) { mws.webserver->send(400,F("text/plain"),F("BadRequest")); return; }
                     if (DisplayManager.indicatorParser(1,mws.webserver->arg("plain").c_str())){
                      mws.webserver->send(200,F("text/plain"),F("OK")); 
                     }else{
                          mws.webserver->send(500,F("text/plain"),F("ErrorParsingJson")); 
                     } });
     mws.addHandler("/api/indicator2", HTTP_POST, []()
-                   { 
+                   {
+                    if (isBodyOversized()) { mws.webserver->send(400,F("text/plain"),F("BadRequest")); return; }
                     if (DisplayManager.indicatorParser(2,mws.webserver->arg("plain").c_str())){
                      mws.webserver->send(200,F("text/plain"),F("OK")); 
                     }else{
                          mws.webserver->send(500,F("text/plain"),F("ErrorParsingJson")); 
                     } });
     mws.addHandler("/api/indicator3", HTTP_POST, []()
-                   { 
+                   {
+                    if (isBodyOversized()) { mws.webserver->send(400,F("text/plain"),F("BadRequest")); return; }
                     if (DisplayManager.indicatorParser(3,mws.webserver->arg("plain").c_str())){
                      mws.webserver->send(200,F("text/plain"),F("OK")); 
                     }else{


### PR DESCRIPTION
## Problem

POST endpoints that parse JSON (`/api/notify`, `/api/custom`, `/api/indicator1-3`, etc.) have no payload size limit. Sending a large payload causes ArduinoJson to allocate unbounded memory via `DynamicJsonDocument`, exhausting the ESP32 heap. After a few oversized requests, even normal-sized requests start failing with `500 ErrorParsingJson` because there is not enough free heap left.

## Root cause

The WebServer reads the full request body into `arg("plain")` regardless of size, then each handler passes it directly to ArduinoJson for parsing. ArduinoJson allocates roughly `1.3x` the input size for its internal document. On an ESP32 with ~200KB free heap, a single 32KB payload can consume a significant portion of available memory, and the fragmentation left behind can prevent subsequent allocations from succeeding.

## Fix

Add a static `isBodyOversized()` helper that checks `arg("plain").length() > 8192` before any JSON parsing. If the body exceeds 8KB, the handler immediately returns `400 Bad Request` without allocating a `DynamicJsonDocument`.

The 8KB limit matches the existing `MQTT_MAX_PACKET_SIZE` (defined in `platformio.ini`), so HTTP and MQTT have the same maximum payload size.

### Guarded endpoints (parse JSON):
`/api/moodlight`, `/api/notify`, `/api/apps` (POST), `/api/settings` (POST), `/api/reorder`, `/api/custom`, `/api/indicator1`, `/api/indicator2`, `/api/indicator3`

### Not guarded (plain-text / small payloads):
`/api/power`, `/api/sleep`, `/api/rtttl`, `/api/sound`, `/api/r2d2`, `/api/switch`

## How to reproduce

### Test script

```bash
IP="your_ip"

# 1. Send 10KB payload to /api/notify
python3 -c "import json; print(json.dumps({'text': 'A'*10000}))" | \
  curl -s -o /dev/null -w "10KB /api/notify:    HTTP %{http_code}\n" \
  -X POST http://$IP/api/notify -d @-

# 2. Send 10KB payload to /api/custom
python3 -c "import json; print(json.dumps({'text': 'A'*10000}))" | \
  curl -s -o /dev/null -w "10KB /api/custom:    HTTP %{http_code}\n" \
  -X POST "http://$IP/api/custom?name=test" -d @-

# 3. Now try a normal request
curl -s -o /dev/null -w "Normal /api/notify:   HTTP %{http_code}\n" \
  -X POST http://$IP/api/notify -d '{"text":"hello","duration":3}'
```

### Before (main branch, firmware 0.98)

```
10KB /api/notify:    HTTP 500    ← ArduinoJson fails on large input
10KB /api/custom:    HTTP 200    ← accepted, consumes heap
Normal /api/notify:  HTTP 500    ← subsequent normal request ALSO fails (heap exhausted)
```

After sending oversized payloads, the device enters a degraded state where even valid requests fail until reboot.

### After (this branch)

```
10KB /api/notify:    HTTP 400    ← rejected before parsing
10KB /api/custom:    HTTP 400    ← rejected before parsing
Normal /api/notify:  HTTP 200    ← works fine, heap is clean
```
