### PR TITLE
Refactor: extract renderColoredText to deduplicate text rendering

### DIFF
--- a/src/Apps.cpp
+++ b/src/Apps.cpp
@@ -683,19 +683,8 @@ void ShowCustomApp(String name, FastLED_NeoMatrix *matrix, MatrixDisplayUiState 
         else
         {
             String text = replacePlaceholders(ca->text);
-            if (ca->rainbow)
-            {
-                DisplayManager.HSVtext(x + textX + ca->textOffset, 6 + y, text.c_str(), false, ca->textCase);
-            }
-            else if (ca->gradient[0] > -1 && ca->gradient[1] > -1)
-            {
-                DisplayManager.GradientText(x + textX + ca->textOffset, 6 + y, text.c_str(), ca->gradient[0], ca->gradient[1], false, ca->textCase);
-            }
-            else
-            {
-                DisplayManager.setTextColor(TextEffect(ca->color, ca->fade, ca->blink));
-                DisplayManager.printText(x + textX + ca->textOffset, y + 6, text.c_str(), false, ca->textCase);
-            }
+            DisplayManager.renderColoredText(x + textX + ca->textOffset, 6 + y, text.c_str(),
+                ca->rainbow, ca->gradient[0], ca->gradient[1], ca->color, ca->fade, ca->blink, ca->textCase);
         }
     }
     else
@@ -713,19 +702,8 @@ void ShowCustomApp(String name, FastLED_NeoMatrix *matrix, MatrixDisplayUiState 
         }
         else
         {
-            if (ca->rainbow)
-            {
-                DisplayManager.HSVtext(x + ca->scrollposition + ca->textOffset, 6 + y, text.c_str(), false, ca->textCase);
-            }
-            else if (ca->gradient[0] > -1 && ca->gradient[1] > -1)
-            {
-                DisplayManager.GradientText(x + ca->scrollposition + ca->textOffset, 6 + y, text.c_str(), ca->gradient[0], ca->gradient[1], false, ca->textCase);
-            }
-            else
-            {
-                DisplayManager.setTextColor(TextEffect(ca->color, ca->fade, ca->blink));
-                DisplayManager.printText(x + ca->scrollposition + ca->textOffset, 6 + y, text.c_str(), false, ca->textCase);
-            }
+            DisplayManager.renderColoredText(x + ca->scrollposition + ca->textOffset, 6 + y, text.c_str(),
+                ca->rainbow, ca->gradient[0], ca->gradient[1], ca->color, ca->fade, ca->blink, ca->textCase);
         }
     }
 

--- a/src/DisplayManager.cpp
+++ b/src/DisplayManager.cpp
@@ -280,6 +280,27 @@ void DisplayManager_::GradientText(int16_t x, int16_t y, const char *text, int c
     matrix->show();
 }
 
+// Renders text with rainbow, gradient, or solid color effect.
+// Caller computes final x/y position; this method only handles the rendering mode.
+void DisplayManager_::renderColoredText(int16_t x, int16_t y, const char *text,
+    bool rainbow, int gradient0, int gradient1,
+    uint32_t color, uint32_t fade, uint32_t blink, byte textCase)
+{
+    if (rainbow)
+    {
+        HSVtext(x, y, text, false, textCase);
+    }
+    else if (gradient0 > -1 && gradient1 > -1)
+    {
+        GradientText(x, y, text, gradient0, gradient1, false, textCase);
+    }
+    else
+    {
+        setTextColor(TextEffect(color, fade, blink));
+        printText(x, y, text, false, textCase);
+    }
+}
+
 void pushCustomApp(String name, int position)
 {
   if (customApps.count(name) == 0)

--- a/src/DisplayManager.h
+++ b/src/DisplayManager.h
@@ -42,6 +42,7 @@ public:
     bool generateCustomPage(const String &name, JsonObject doc, bool preventSave);
     void printText(int16_t x, int16_t y, const char *text, bool centered, byte textCase);
     void GradientText(int16_t x, int16_t y, const char *text, int color1, int color2, bool clear, byte textCase);
+    void renderColoredText(int16_t x, int16_t y, const char *text, bool rainbow, int gradient0, int gradient1, uint32_t color, uint32_t fade, uint32_t blink, byte textCase);
     bool setAutoTransition(bool active);
     bool switchToApp(const char *json);
     void setNewSettings(const char *json);

--- a/src/Overlays.cpp
+++ b/src/Overlays.cpp
@@ -282,20 +282,9 @@ void NotifyOverlay(FastLED_NeoMatrix *matrix, MatrixDisplayUiState *state, GifPl
         }
         else
         {
-            if (notifications[0].rainbow)
-            {
-                DisplayManager.HSVtext(textX + notifications[0].textOffset, 6, notifications[0].text.c_str(), false, notifications[0].textCase);
-            }
-            else if (notifications[0].gradient[0] > -1 && notifications[0].gradient[1] > -1)
-            {
-                DisplayManager.GradientText(textX + notifications[0].textOffset, 6, notifications[0].text.c_str(), notifications[0].gradient[0], notifications[0].gradient[1], false, notifications[0].textCase);
-            }
-            else
-            {
-                DisplayManager.setTextColor(TextEffect(notifications[0].color, notifications[0].fade, notifications[0].blink));
-
-                DisplayManager.printText(textX + notifications[0].textOffset, 6, notifications[0].text.c_str(), false, notifications[0].textCase);
-            }
+            DisplayManager.renderColoredText(textX + notifications[0].textOffset, 6, notifications[0].text.c_str(),
+                notifications[0].rainbow, notifications[0].gradient[0], notifications[0].gradient[1],
+                notifications[0].color, notifications[0].fade, notifications[0].blink, notifications[0].textCase);
         }
     }
     else
@@ -319,21 +308,9 @@ void NotifyOverlay(FastLED_NeoMatrix *matrix, MatrixDisplayUiState *state, GifPl
         }
         else
         {
-            if (notifications[0].rainbow)
-            {
-                // Display scrolling text in rainbow color if enabled
-                DisplayManager.HSVtext(notifications[0].scrollposition, 6, notifications[0].text.c_str(), false, notifications[0].textCase);
-            }
-            else if (notifications[0].gradient[0] > -1 && notifications[0].gradient[1] > -1)
-            {
-                DisplayManager.GradientText(notifications[0].scrollposition + notifications[0].textOffset, 6, notifications[0].text.c_str(), notifications[0].gradient[0], notifications[0].gradient[1], false, notifications[0].textCase);
-            }
-            else
-            {
-                // Set text color
-                DisplayManager.setTextColor(TextEffect(notifications[0].color, notifications[0].fade, notifications[0].blink));
-                DisplayManager.printText(notifications[0].scrollposition + notifications[0].textOffset, 6, notifications[0].text.c_str(), false, notifications[0].textCase);
-            }
+            DisplayManager.renderColoredText(notifications[0].scrollposition + notifications[0].textOffset, 6, notifications[0].text.c_str(),
+                notifications[0].rainbow, notifications[0].gradient[0], notifications[0].gradient[1],
+                notifications[0].color, notifications[0].fade, notifications[0].blink, notifications[0].textCase);
         }
     }
 


### PR DESCRIPTION
Extract rainbow/gradient/plain text rendering into a shared `DisplayManager::renderColoredText()` method, replacing 4 identical blocks across `Apps.cpp` and `Overlays.cpp`.

### Bug fix

Scrolling notification text in rainbow mode was missing `textOffset`, causing inconsistent positioning compared to gradient and plain text modes (`Overlays.cpp:325`).

### Changes

- `src/DisplayManager.h` — new method declaration
- `src/DisplayManager.cpp` — `renderColoredText()` implementation
- `src/Apps.cpp` — replaced 2 duplicated blocks (non-scrolling + scrolling)
- `src/Overlays.cpp` — replaced 2 duplicated blocks (non-scrolling + scrolling, includes textOffset fix)