### PR TITLE
feat: add optional TLS support for MQTT connections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .pio
 .vscode/.browse.c_cpp.db*
 .vscode/c_cpp_properties.json

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,7 +14,7 @@ default_envs = ulanzi
 [env]
 framework = arduino
 board_build.f_cpu = 240000000L
-upload_speed = 921600
+upload_speed = 115200
 monitor_speed = 115200
 monitor_filters = esp32_exception_decoder
 lib_deps = 

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -354,6 +354,7 @@ uint16_t MQTT_PORT = 1883;
 String MQTT_USER;
 String MQTT_PASS;
 String MQTT_PREFIX;
+bool MQTT_TLS = false;
 bool IO_BROKER = false;
 bool NET_STATIC = false;
 bool SHOW_TIME = true;

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -41,6 +41,7 @@ extern uint16_t MQTT_PORT;
 extern String MQTT_USER;
 extern String MQTT_PASS;
 extern String MQTT_PREFIX;
+extern bool MQTT_TLS;
 extern bool IO_BROKER;
 extern bool NET_STATIC;
 extern bool SHOW_TIME;

--- a/src/MQTTManager.cpp
+++ b/src/MQTTManager.cpp
@@ -4,6 +4,7 @@
 #include "ServerManager.h"
 #include <ArduinoHA.h>
 #include <WiFi.h>
+#include <WiFiClientSecure.h>
 #include <ArduinoJson.h>
 #include "Dictionary.h"
 #include "PeripheryManager.h"
@@ -12,9 +13,12 @@
 
 const uint16_t PORT = 1883;
 
-WiFiClient espClient;
+WiFiClientSecure secureClient;
+WiFiClient plainClient;
 HADevice device;
-HAMqtt mqtt(espClient, device, 26);
+HAMqtt *mqttPtr = nullptr;
+
+#define mqtt (*mqttPtr)
 
 HALight *Matrix, *Indikator1, *Indikator2, *Indikator3 = nullptr;
 HASelect *BriMode, *transEffect = nullptr;
@@ -463,7 +467,6 @@ bool MQTTManager_::isConnected()
 
 void connect()
 {
-
     mqtt.onMessage(onMqttMessage);
     mqtt.onConnected(onMqttConnected);
 
@@ -537,6 +540,15 @@ void MQTTManager_::sendStats()
 
 void MQTTManager_::setup()
 {
+    if (MQTT_TLS)
+    {
+        secureClient.setInsecure();
+        mqttPtr = new HAMqtt(secureClient, device, 26);
+    }
+    else
+    {
+        mqttPtr = new HAMqtt(plainClient, device, 26);
+    }
 
     if (HA_DISCOVERY)
     {
@@ -741,7 +753,7 @@ void MQTTManager_::setup()
 
 void MQTTManager_::tick()
 {
-    if (MQTT_HOST != "")
+    if (mqttPtr != nullptr && MQTT_HOST != "")
     {
         mqtt.loop();
     }
@@ -755,6 +767,9 @@ void MQTTManager_::tick()
 
 void MQTTManager_::publish(const char *topic, const char *payload)
 {
+    if (mqttPtr == nullptr)
+        return;
+
     char result[100];
     strcpy(result, MQTT_PREFIX.c_str());
     strcat(result, "/");
@@ -768,7 +783,7 @@ void MQTTManager_::publish(const char *topic, const char *payload)
 
 void MQTTManager_::rawPublish(const char *prefix, const char *topic, const char *payload)
 {
-    if (!mqtt.isConnected())
+    if (mqttPtr == nullptr || !mqtt.isConnected())
         return;
     char result[100];
     strcpy(result, prefix);
@@ -864,15 +879,21 @@ void MQTTManager_::setIndicatorState(uint8_t indicator, bool state, uint32_t col
 
 void MQTTManager_::beginPublish(const char *topic, unsigned int plength, boolean retained)
 {
+    if (mqttPtr == nullptr)
+        return;
     mqtt.beginPublish(topic, plength, retained);
 }
 
 void MQTTManager_::writePayload(const char *data, const uint16_t length)
 {
+    if (mqttPtr == nullptr)
+        return;
     mqtt.writePayload(data, length);
 }
 
 void MQTTManager_::endPublish()
 {
+    if (mqttPtr == nullptr)
+        return;
     mqtt.endPublish();
 }

--- a/src/ServerManager.cpp
+++ b/src/ServerManager.cpp
@@ -235,6 +235,7 @@ void ServerManager_::setup()
         mws.addOption("Username", MQTT_USER);
         mws.addOption("Password", MQTT_PASS);
         mws.addOption("Prefix", MQTT_PREFIX);
+        mws.addOption("TLS", MQTT_TLS);
         mws.addOption("Homeassistant Discovery", HA_DISCOVERY);
         mws.addOptionBox("Time");
         mws.addOption("NTP Server", NTP_SERVER);
@@ -366,6 +367,7 @@ void ServerManager_::loadSettings()
         MQTT_PASS = doc["Password"].as<String>();
         MQTT_PREFIX = doc["Prefix"].as<String>();
         MQTT_PREFIX.trim();
+        MQTT_TLS = doc.containsKey("TLS") ? doc["TLS"].as<bool>() : false;
         NET_STATIC = doc["Static IP"];
         HA_DISCOVERY = doc["Homeassistant Discovery"];
         NET_IP = doc["Local IP"].as<String>();


### PR DESCRIPTION
## Summary

Adds optional TLS support for MQTT connections, enabling secure communication with brokers that require TLS (e.g., HiveMQ Cloud on port 8883).

## Changes

- **TLS client support**: Add `WiFiClientSecure` alongside `WiFiClient` for runtime selection based on config
- **`MQTT_TLS` config variable**: New boolean in `Globals.h/cpp`, persisted in `DoNotTouch.json`
- **Web UI toggle**: TLS checkbox in the MQTT settings section
- **Deferred HAMqtt init**: Move `HAMqtt` construction from global scope to `MQTTManager::setup()` to allow runtime client selection (secure vs plain)
- **Null-safety**: Add `mqttPtr` null checks in `publish()`, `rawPublish()`, `tick()`, `beginPublish()`, `writePayload()`, `endPublish()` to prevent crash if MQTT methods are called before `setup()`
- **Upload speed**: Reduce default `upload_speed` to 115200 for more reliable serial flashing

## Usage

1. In the AWTRIX web UI, go to MQTT settings
2. Enable the **TLS** checkbox
3. Set port to `8883` (or your broker's TLS port)
4. Save and restart

Uses `setInsecure()` mode (no certificate verification) to keep flash size minimal while still encrypting the connection.

## Testing

- Tested with HiveMQ Cloud (TLS on port 8883) — connects and receives messages
- Tested without TLS — backwards compatible, no behavior change
- Verified no crash on boot when MQTT is not configured (null-safety checks)