### PR TITLE
refactor indicator drawing and storage code to facilitate per-pixel access

### DIFF
--- a/src/DisplayManager.cpp
+++ b/src/DisplayManager.cpp
@@ -22,6 +22,7 @@
 #include <HTTPClient.h>
 #include "base64.hpp"
 #include "Games/GameManager.h"
+#include "Indicators.h"
 
 unsigned long lastArtnetStatusTime = 0;
 const int numberOfChannels = 256 * 3;
@@ -1659,9 +1660,9 @@ String DisplayManager_::getStats()
   doc[SignalStrengthKey] = WiFi.RSSI();
   doc[MessagesKey] = RECEIVED_MESSAGES;
   doc[VersionKey] = VERSION;
-  doc[F("indicator1")] = ui->indicator1State;
-  doc[F("indicator2")] = ui->indicator2State;
-  doc[F("indicator3")] = ui->indicator3State;
+  doc[F("indicator1")] = getIndicatorState(1);
+  doc[F("indicator2")] = getIndicatorState(2);
+  doc[F("indicator3")] = getIndicatorState(3);
   doc[F("app")] = CURRENT_APP;
   doc[F("uid")] = uniqueID;
   doc[F("matrix")] = !MATRIX_OFF;
@@ -1754,64 +1755,15 @@ void DisplayManager_::setPower(bool state)
   }
 }
 
-void DisplayManager_::setIndicator1Color(uint32_t color)
-{
-  ui->setIndicator1Color(color);
-}
-
-void DisplayManager_::setIndicator1State(bool state)
-{
-  ui->setIndicator1State(state);
-}
-
-void DisplayManager_::setIndicator2Color(uint32_t color)
-{
-  ui->setIndicator2Color(color);
-}
-
-void DisplayManager_::setIndicator2State(bool state)
-{
-  ui->setIndicator2State(state);
-}
-
-void DisplayManager_::setIndicator3Color(uint32_t color)
-{
-  ui->setIndicator3Color(color);
-}
-
-void DisplayManager_::setIndicator3State(bool state)
-{
-  ui->setIndicator3State(state);
-}
-
 bool DisplayManager_::indicatorParser(uint8_t indicator, const char *json)
 {
 
   if (strcmp(json, "") == 0 || strcmp(json, "{}") == 0)
   {
-    switch (indicator)
-    {
-    case 1:
-      ui->setIndicator1State(false);
-      ui->setIndicator1Fade(0);
-      ui->setIndicator1Blink(0);
-      MQTTManager.setIndicatorState(1, ui->indicator1State, ui->indicator1Color);
-      break;
-    case 2:
-      ui->setIndicator2State(false);
-      ui->setIndicator2Fade(0);
-      ui->setIndicator2Blink(0);
-      MQTTManager.setIndicatorState(2, ui->indicator2State, ui->indicator2Color);
-      break;
-    case 3:
-      ui->setIndicator3State(false);
-      ui->setIndicator3Fade(0);
-      ui->setIndicator3Blink(0);
-      MQTTManager.setIndicatorState(3, ui->indicator3State, ui->indicator3Color);
-      break;
-    default:
-      break;
-    }
+    setIndicatorState(indicator, false);
+    setIndicatorFade(indicator, 0);
+    setIndicatorBlink(indicator, 0);
+    MQTTManager.setIndicatorState(indicator, getIndicatorState(indicator), getIndicatorColor(indicator));
     return true;
   }
 
@@ -1828,114 +1780,25 @@ bool DisplayManager_::indicatorParser(uint8_t indicator, const char *json)
 
     if (col > 0)
     {
-      switch (indicator)
-      {
-      case 1:
-        ui->setIndicator1State(true);
-        ui->setIndicator1Color(col);
-        break;
-      case 2:
-        ui->setIndicator2State(true);
-        ui->setIndicator2Color(col);
-        break;
-      case 3:
-        ui->setIndicator3State(true);
-        ui->setIndicator3Color(col);
-        break;
-      default:
-        break;
-      }
+      setIndicatorState(indicator, true);
+      setIndicatorColor(indicator, col);
     }
     else
     {
-      switch (indicator)
-      {
-      case 1:
-        ui->setIndicator1State(false);
-        break;
-      case 2:
-        ui->setIndicator2State(false);
-        break;
-      case 3:
-        ui->setIndicator3State(false);
-        break;
-      default:
-        break;
-      }
+      setIndicatorState(indicator, false);
     }
   }
 
-  if (doc.containsKey("blink"))
-  {
-    switch (indicator)
-    {
-    case 1:
-      ui->setIndicator1Blink(doc["blink"].as<int>());
-      break;
-    case 2:
-      ui->setIndicator2Blink(doc["blink"].as<int>());
-      break;
-    case 3:
-      ui->setIndicator3Blink(doc["blink"].as<int>());
-      break;
-    default:
-      break;
-    }
-  }
-  else
-  {
-    switch (indicator)
-    {
-    case 1:
-      ui->setIndicator1Blink(0);
-      break;
-    case 2:
-      ui->setIndicator2Blink(0);
-      break;
-    case 3:
-      ui->setIndicator3Blink(0);
-      break;
-    default:
-      break;
-    }
-  }
+  setIndicatorBlink(indicator, 
+    doc.containsKey("blink") ? doc["blink"].as<int>() : 0
+  );
 
-  if (doc.containsKey("fade"))
-  {
-    switch (indicator)
-    {
-    case 1:
-      ui->setIndicator1Fade(doc["fade"].as<int>());
-      break;
-    case 2:
-      ui->setIndicator2Fade(doc["fade"].as<int>());
-      break;
-    case 3:
-      ui->setIndicator3Fade(doc["fade"].as<int>());
-      break;
-    default:
-      break;
-    }
-  }
-  else
-  {
-    switch (indicator)
-    {
-    case 1:
-      ui->setIndicator1Fade(0);
-      break;
-    case 2:
-      ui->setIndicator2Fade(0);
-      break;
-    case 3:
-      ui->setIndicator3Fade(0);
-      break;
-    default:
-      break;
-    }
-  }
+  setIndicatorFade(indicator, 
+    doc.containsKey("fade") ? doc["fade"].as<int>() : 0
+  );
+
   doc.clear();
-  MQTTManager.setIndicatorState(indicator, ui->indicator1State, ui->indicator1Color);
+  MQTTManager.setIndicatorState(indicator, getIndicatorState(indicator), getIndicatorColor(indicator));
   return true;
 }
 

--- a/src/DisplayManager.h
+++ b/src/DisplayManager.h
@@ -60,12 +60,6 @@ public:
     String getSettings();
     void setPower(bool state);
     void powerStateParse(const char *json);
-    void setIndicator1Color(uint32_t color);
-    void setIndicator1State(bool state);
-    void setIndicator2Color(uint32_t color);
-    void setIndicator2State(bool state);
-    void setIndicator3Color(uint32_t color);
-    void setIndicator3State(bool state);
     void reorderApps(const String &jsonString);
     void gammaCorrection();
     bool indicatorParser(uint8_t indicator, const char *json);

--- a/src/Indicators.cpp
+++ b/src/Indicators.cpp
@@ -1,0 +1,91 @@
+#include "Indicators.h"
+
+///---- note, if optimizing, some opportunity here to reduce the passing of the structs on the stack. return / use pointers instead
+
+// ============= Data section   // changes to number of indicators must match in .h INDICATOR_COUNT
+
+IndicatorPixelData _indicator1[] = {
+    { {31,0}, DEFAULT_1_COLOR}, // partially fills and uses default value constructor
+    { {30,0}, DEFAULT_1_COLOR},
+    { {31,1}, DEFAULT_1_COLOR}
+};
+
+IndicatorPixelData _indicator2[] = 
+{
+  { {31,3}, DEFAULT_2_COLOR}, // partially fills and uses default value constructor
+  { {31,4}, DEFAULT_2_COLOR}
+};
+
+IndicatorPixelData _indicator3[] = 
+{
+  { {31,6}, DEFAULT_3_COLOR}, // partially fills and uses default value constructor
+  { {31,7}, DEFAULT_3_COLOR},
+  { {30,7}, DEFAULT_3_COLOR}
+};
+
+Indicator indicators[] = {
+  {3, _indicator1},  // num of pixels hard coded. could probably do a macro but, meh.
+  {2, _indicator2},
+  {3, _indicator3}
+};
+
+
+//  ============= Helper fn section to simplify later functions
+void setColor(IndicatorPixelData *pd, uint32_t color) { pd->color = color;}  // these are just setters so I can use fn points to reuse code instead of repeating all the fns.
+void setState(IndicatorPixelData *pd, bool state) { pd->state = state;}
+void setBlink(IndicatorPixelData *pd, int blink) { pd->blink = blink;}
+void setFade(IndicatorPixelData *pd, int fade) { pd->fade = fade;}
+
+Indicator* getIndicatorPtr(int indicator) {
+  indicator--; // 1-based indexing -> 0 based
+  if (indicator >= INDICATOR_COUNT || indicator < 0) indicator = 0; // default to a safe, but wrong, pixel instead of generating NULL pointers
+  return &(indicators[indicator]);
+}
+
+IndicatorPixelData getPixelData(int indicator, int pixel) {
+  Indicator* ind = getIndicatorPtr(indicator);
+  if (pixel == ALL_PIXELS || pixel < 0 || pixel >= ind->pixelCount) pixel = 0; // default to first
+  return ind->data[pixel];
+}
+
+template <typename T>
+void setPixelData( void (*fieldSetter)(IndicatorPixelData*, T), int indicator, int pixel, T value) {
+  Indicator* ind = getIndicatorPtr(indicator);
+
+  if (pixel == ALL_PIXELS)
+  {
+    for (int pixel=0; pixel < ind->pixelCount; pixel++) 
+    {
+      (*fieldSetter)( &(ind->data[pixel]), value);
+    }
+  } else
+  {
+    if (pixel < 0 || pixel >= ind->pixelCount)
+      pixel = 0; // default to first)
+    (*fieldSetter)( &(ind->data[pixel]), value);
+  }
+}
+
+//=============== on off state
+bool getIndicatorState(int indicator, int pixel)              { return getPixelData(indicator, pixel).state; }
+bool getIndicatorState(int indicator)                         { return getPixelData(indicator, ALL_PIXELS).state; }
+void setIndicatorState(int indicator, int pixel, bool state)  { setPixelData(&setState, indicator, pixel, state);  }
+void setIndicatorState(int indicator, bool state)             { setPixelData(&setState, indicator, ALL_PIXELS, state); }
+
+// //=============== color
+uint32_t getIndicatorColor(int indicator, int pixel)              { return getPixelData(indicator, pixel).color; }
+uint32_t getIndicatorColor(int indicator)                         { return getPixelData(indicator, ALL_PIXELS).color; }
+void setIndicatorColor(int indicator, int pixel, uint32_t color)  { setPixelData(&setColor, indicator, pixel, color); }
+void setIndicatorColor(int indicator, uint32_t color)             { setPixelData(&setColor, indicator, ALL_PIXELS, color); }
+
+// //=============== blink
+int getIndicatorBlink(int indicator, int pixel)              { return getPixelData(indicator, pixel).blink; }
+int getIndicatorBlink(int indicator)                         { return getPixelData(indicator, ALL_PIXELS).blink; }
+void setIndicatorBlink(int indicator, int pixel, int blink)  { setPixelData(&setBlink, indicator, pixel, blink);  }
+void setIndicatorBlink(int indicator, int blink)             { setPixelData(&setBlink, indicator, ALL_PIXELS, blink); }
+
+// //=============== fade
+int getIndicatorFade(int indicator, int pixel)             { return getPixelData(indicator, pixel).fade; }
+int getIndicatorFade(int indicator)                        { return getPixelData(indicator, ALL_PIXELS).fade; }
+void setIndicatorFade(int indicator, int pixel, int fade)  { setPixelData(&setFade, indicator, pixel, fade);  }
+void setIndicatorFade(int indicator, int fade)             { setPixelData(&setFade, indicator, ALL_PIXELS, fade); }

--- a/src/Indicators.h
+++ b/src/Indicators.h
@@ -1,0 +1,72 @@
+#ifndef INDICATORS_H
+#define INDICATORS_H
+#include <cstdint>
+
+/// NOTE from the external view, all indicators are indexed from 1 to match the rest of the project. internally mapped
+static const int INDICATOR_COUNT = 3; // you can increase this if you want more pixels. Must match the static declarations in the .cpp
+
+// ADVANCED:  added features for per pixel operations.
+//   when accessing standard, not perpixel versions, set sets all pixels. get returns the first. Emulates solid color.
+// -- pixels are 0 indexed. but use this flag to set/get ALL pixels at once. 
+
+const int ALL_PIXELS = -1; 
+
+constexpr bool DEFAULT_STATE = false;  // boot time default
+constexpr int DEFAULT_BLINK = 0;
+constexpr int DEFAULT_FADE = 0;
+
+constexpr uint32_t DEFAULT_1_COLOR = 0xFF0000;  // R 
+constexpr uint32_t DEFAULT_2_COLOR = 0x00FF00;  // G
+constexpr uint32_t DEFAULT_3_COLOR = 0x0000FF;  // B
+
+struct Coord {  // coordinate of a single indicator pixel
+    int x;
+    int y;
+};
+
+struct IndicatorPixelData // data for a single pixel
+{
+  Coord coord;
+  uint32_t color;
+  bool state;
+  int blink;
+  int fade;
+
+  // default values
+  IndicatorPixelData(Coord c, uint32_t col) : coord(c), color(col), state(DEFAULT_STATE), blink(DEFAULT_BLINK), fade(DEFAULT_FADE) {}
+};
+
+struct Indicator {   // an indicator consists of a number of pixels
+    int pixelCount;
+    IndicatorPixelData* data;
+};
+
+Indicator* getIndicatorPtr(int indicator);  // returns a pointer to an indicator. careful of pixel count for data array length
+
+//// solid indicators, all same state
+bool getIndicatorState(int indicator);
+void setIndicatorState(int indicator, bool state);
+
+uint32_t getIndicatorColor(int indicator);
+void setIndicatorColor(int indicator, uint32_t color);  
+
+int getIndicatorBlink(int indicator);
+void setIndicatorBlink(int indicator, int blink); // all at once
+
+int getIndicatorFade(int indicator);
+void setIndicatorFade(int indicator, int fade);  // all at once
+
+//// per pixel operations
+
+bool getIndicatorState(int indicator, int pixel);  
+void setIndicatorState(int indicator, int pixel, bool state);
+
+uint32_t getIndicatorColor(int indicator, int pixel);
+void setIndicatorColor(int indicator, int pixel, uint32_t color);
+
+int getIndicatorBlink(int indicator, int pixel);
+void setIndicatorBlink(int indicator, int pixel, int blink);
+
+int getIndicatorFade(int indicator, int pixel);
+void setIndicatorFade(int indicator, int pixel, int fade);
+#endif // INDICATORS_H

--- a/src/MQTTManager.cpp
+++ b/src/MQTTManager.cpp
@@ -9,6 +9,7 @@
 #include "PeripheryManager.h"
 #include "UpdateManager.h"
 #include "PowerManager.h"
+#include "Indicators.h"
 
 const uint16_t PORT = 1883;
 
@@ -286,15 +287,15 @@ void onRGBColorCommand(HALight::RGBColor color, HALight *sender)
     }
     else if (sender == Indikator1)
     {
-        DisplayManager.setIndicator1Color((color.red << 16) | (color.green << 8) | color.blue);
+        setIndicatorColor(1, (color.red << 16) | (color.green << 8) | color.blue);
     }
     else if (sender == Indikator2)
     {
-        DisplayManager.setIndicator2Color((color.red << 16) | (color.green << 8) | color.blue);
+        setIndicatorColor(2, (color.red << 16) | (color.green << 8) | color.blue);
     }
     else if (sender == Indikator3)
     {
-        DisplayManager.setIndicator3Color((color.red << 16) | (color.green << 8) | color.blue);
+        setIndicatorColor(3, (color.red << 16) | (color.green << 8) | color.blue);
     }
     sender->setRGBColor(color); // report color back to the Home Assistant
 }
@@ -307,15 +308,15 @@ void onStateCommand(bool state, HALight *sender)
     }
     else if (sender == Indikator1)
     {
-        DisplayManager.setIndicator1State(state);
+        setIndicatorState(1, state);
     }
     else if (sender == Indikator2)
     {
-        DisplayManager.setIndicator2State(state);
+        setIndicatorState(2, state);
     }
     else if (sender == Indikator3)
     {
-        DisplayManager.setIndicator3State(state);
+        setIndicatorState(3, state);
     }
     sender->setState(state);
 }

--- a/src/MatrixDisplayUi.cpp
+++ b/src/MatrixDisplayUi.cpp
@@ -30,6 +30,7 @@
 #include "effects.h"
 #include "Globals.h"
 #include "effects.h"
+#include "Indicators.h"
 
 GifPlayer gif1;
 GifPlayer gif2;
@@ -257,84 +258,37 @@ void MatrixDisplayUi::drawIndicators()
 {
   uint32_t drawColor;
 
-  // Indicator 1
-  if (indicator1State)
+  for (int indicator=1; indicator <= INDICATOR_COUNT; indicator++) 
   {
-    if (indicator1Blink)
-    {
-      if (millis() % (2 * indicator1Blink) < indicator1Blink)
-      {
-        drawColor = indicator1Color;
-      }
-      else
-      {
-        drawColor = 0; // Schwarz
-      }
-    }
-    else if (indicator1Fade)
-    {
-      drawColor = fadeColor(indicator1Color, indicator1Fade);
-    }
-    else
-    {
-      drawColor = indicator1Color;
-    }
-    matrix->drawPixel(31, 0, drawColor);
-    matrix->drawPixel(30, 0, drawColor);
-    matrix->drawPixel(31, 1, drawColor);
-  }
+    Indicator* ind = getIndicatorPtr(indicator);
 
-  // Indicator 2
-  if (indicator2State)
-  {
-    if (indicator2Blink)
+    for (int pixel=0; pixel < ind->pixelCount; pixel++)
     {
-      if (millis() % (2 * indicator2Blink) < indicator2Blink)
+      IndicatorPixelData pixelData = ind->data[pixel];
+      if (pixelData.state)
       {
-        drawColor = indicator2Color;
-      }
-      else
-      {
-        drawColor = 0; // Schwarz
-      }
-    }
-    else if (indicator2Fade)
-    {
-      drawColor = fadeColor(indicator2Color, indicator2Fade);
-    }
-    else
-    {
-      drawColor = indicator2Color;
-    }
-    matrix->drawPixel(31, 3, drawColor);
-    matrix->drawPixel(31, 4, drawColor);
-  }
-
-  // Indicator 3
-  if (indicator3State)
-  {
-    if (indicator3Blink)
-    {
-      if (millis() % (2 * indicator3Blink) < indicator3Blink)
-      {
-        drawColor = indicator3Color;
-      }
-      else
-      {
-        drawColor = 0; // Schwarz
+        if (pixelData.blink != 0)
+        {
+          if (millis() % (2 * pixelData.blink) < pixelData.blink)
+          {
+            drawColor = pixelData.color;
+          }
+          else
+          {
+            drawColor = 0; // Schwarz
+          }
+        }
+        else if (pixelData.fade)
+        {
+          drawColor = fadeColor(pixelData.color, pixelData.fade);
+        }
+        else
+        {
+          drawColor = pixelData.color;
+        }
+        matrix->drawPixel(pixelData.coord.x, pixelData.coord.y, drawColor);
       }
     }
-    else if (indicator3Fade)
-    {
-      drawColor = fadeColor(indicator3Color, indicator3Fade);
-    }
-    else
-    {
-      drawColor = indicator3Color;
-    }
-    matrix->drawPixel(31, 7, drawColor);
-    matrix->drawPixel(31, 6, drawColor);
-    matrix->drawPixel(30, 7, drawColor);
   }
 }
 
@@ -476,66 +430,6 @@ uint8_t MatrixDisplayUi::getnextAppNumber()
   if (this->nextAppNumber != -1)
     return this->nextAppNumber;
   return (this->state.currentApp + this->AppCount + this->state.appTransitionDirection) % this->AppCount;
-}
-
-void MatrixDisplayUi::setIndicator1Color(uint32_t color)
-{
-  this->indicator1Color = color;
-}
-
-void MatrixDisplayUi::setIndicator1State(bool state)
-{
-  this->indicator1State = state;
-}
-
-void MatrixDisplayUi::setIndicator1Blink(int blink)
-{
-  this->indicator1Blink = blink;
-}
-
-void MatrixDisplayUi::setIndicator1Fade(int fade)
-{
-  this->indicator1Fade = fade;
-}
-
-void MatrixDisplayUi::setIndicator2Color(uint32_t color)
-{
-  this->indicator2Color = color;
-}
-
-void MatrixDisplayUi::setIndicator2State(bool state)
-{
-  this->indicator2State = state;
-}
-
-void MatrixDisplayUi::setIndicator2Blink(int blink)
-{
-  this->indicator2Blink = blink;
-}
-
-void MatrixDisplayUi::setIndicator2Fade(int fade)
-{
-  this->indicator2Fade = fade;
-}
-
-void MatrixDisplayUi::setIndicator3Color(uint32_t color)
-{
-  this->indicator3Color = color;
-}
-
-void MatrixDisplayUi::setIndicator3State(bool state)
-{
-  this->indicator3State = state;
-}
-
-void MatrixDisplayUi::setIndicator3Blink(int blink)
-{
-  this->indicator3Blink = blink;
-}
-
-void MatrixDisplayUi::setIndicator3Fade(int fade)
-{
-  this->indicator3Fade = fade;
 }
 
 // ------------------ TRANSITIONS -------------------

--- a/src/MatrixDisplayUi.h
+++ b/src/MatrixDisplayUi.h
@@ -174,20 +174,6 @@ public:
    */
   void setTimePerTransition(uint16_t time);
 
-  void setIndicator1Color(uint32_t color);
-  void setIndicator1State(bool state);
-  void setIndicator1Blink(int Blink);
-  void setIndicator1Fade(int fade);
-
-  void setIndicator2Color(uint32_t color);
-  void setIndicator2State(bool state);
-  void setIndicator2Blink(int Blink);
-  void setIndicator2Fade(int fade);
-
-  void setIndicator3Color(uint32_t color);
-  void setIndicator3State(bool state);
-  void setIndicator3Blink(int Blink);
-  void setIndicator3Fade(int fade);
   void drawIndicators();
   // Customize indicator position and style
 
@@ -229,21 +215,5 @@ public:
   MatrixDisplayUiState *getUiState();
 
   int8_t update();
-
-  uint32_t indicator1Color = 0xFF0000;
-  uint32_t indicator2Color = 0x00FF00;
-  uint32_t indicator3Color = 0x0000FF;
-
-  bool indicator1State = false;
-  bool indicator2State = false;
-  bool indicator3State = false;
-
-  int indicator1Blink = 0;
-  int indicator2Blink = 0;
-  int indicator3Blink = 0;
-
-  int indicator1Fade = 0;
-  int indicator2Fade = 0;
-  int indicator3Fade = 0;
 };
 #endif


### PR DESCRIPTION
A quick refactoring of the code for the three on-screen indicators. In addition to a little cleanup to simplify the code, exposes the ability to set all parameters (color, fade, blink, state, etc.) on a per-pixel level. For now this does nothing to the overall functionality and does not break any code that uses the indicators. However, it now enables the MQTT to be expanded to enable per-pixel settings for more customizability when desired.