### PR TITLE
Add per-fragment blink ("b") for custom app text fragments

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -278,6 +278,8 @@ Here's an example JSON object to draw a red circle, a blue rectangle, and the te
 
 AWTRIX 3 allows you to present text where specific fragments can be colorized. Use an array of fragments with `"t"` representing the text fragment and `"c"` denoting the color's hex value.
 
+Each fragment may also carry an optional `"b"` (Integer, ms): when greater than `0` that fragment blinks at the given interval while the other fragments stay steady. This is the per-fragment counterpart to the app-wide `blinkText`; omitting it (or `0`) falls back to the app-wide `blinkText` value. A typical use is a blinking clock separator, e.g. `[{"t":"12"},{"t":":","b":500},{"t":"34"}]`.
+
 ```json
 {
   "text": [
@@ -287,7 +289,8 @@ AWTRIX 3 allows you to present text where specific fragments can be colorized. U
     },
     {
       "t": "world!",
-      "c": "00FF00"
+      "c": "00FF00",
+      "b": 500
     }
   ],
   "repeat": 2

--- a/src/Apps.cpp
+++ b/src/Apps.cpp
@@ -675,7 +675,8 @@ void ShowCustomApp(String name, FastLED_NeoMatrix *matrix, MatrixDisplayUiState 
             for (size_t i = 0; i < ca->fragments.size(); ++i)
             {
                 String text = replacePlaceholders(ca->fragments[i]);
-                DisplayManager.setTextColor(TextEffect(ca->colors[i], ca->fade, ca->blink));
+                int fragBlink = (i < ca->blinks.size() && ca->blinks[i] > 0) ? ca->blinks[i] : ca->blink;
+                DisplayManager.setTextColor(TextEffect(ca->colors[i], ca->fade, fragBlink));
                 DisplayManager.printText(x + fragmentX, y + 6, text.c_str(), false, ca->textCase);
                 fragmentX += getTextWidth(text.c_str(), ca->textCase);
             }
@@ -706,7 +707,8 @@ void ShowCustomApp(String name, FastLED_NeoMatrix *matrix, MatrixDisplayUiState 
             for (size_t i = 0; i < ca->fragments.size(); ++i)
             {
                 String text = replacePlaceholders(ca->fragments[i]);
-                DisplayManager.setTextColor(TextEffect(ca->colors[i], ca->fade, ca->blink));
+                int fragBlink = (i < ca->blinks.size() && ca->blinks[i] > 0) ? ca->blinks[i] : ca->blink;
+                DisplayManager.setTextColor(TextEffect(ca->colors[i], ca->fade, fragBlink));
                 DisplayManager.printText(x + fragmentX, y + 6, text.c_str(), false, ca->textCase);
                 fragmentX += getTextWidth(text.c_str(), ca->textCase);
             }

--- a/src/Apps.h
+++ b/src/Apps.h
@@ -44,6 +44,7 @@ struct CustomApp
     uint64_t lifetime;
     std::vector<uint32_t> colors;
     std::vector<String> fragments;
+    std::vector<int> blinks;
     int textOffset;
     int iconOffset;
     int progress = -1;

--- a/src/DisplayManager.cpp
+++ b/src/DisplayManager.cpp
@@ -398,10 +398,12 @@ void removeCustomAppFromApps(const String &name, bool setApps)
   DisplayManager.setAppTime(TIME_PER_APP);
 }
 
-bool parseFragmentsText(const JsonArray &fragmentArray, std::vector<uint32_t> &colors, std::vector<String> &fragments, uint32_t standardColor)
+bool parseFragmentsText(const JsonArray &fragmentArray, std::vector<uint32_t> &colors, std::vector<String> &fragments, uint32_t standardColor, std::vector<int> *blinks = nullptr)
 {
   colors.clear();
   fragments.clear();
+  if (blinks)
+    blinks->clear();
 
   for (JsonObject fragmentObj : fragmentArray)
   {
@@ -419,6 +421,8 @@ bool parseFragmentsText(const JsonArray &fragmentArray, std::vector<uint32_t> &c
 
     fragments.push_back(utf8ascii(textFragment));
     colors.push_back(color);
+    if (blinks)
+      blinks->push_back(fragmentObj.containsKey("b") ? fragmentObj["b"].as<int>() : 0);
   }
   return true;
 }
@@ -715,11 +719,12 @@ bool DisplayManager_::generateCustomPage(const String &name, JsonObject doc, boo
 
   customApp.colors.clear();
   customApp.fragments.clear();
+  customApp.blinks.clear();
 
   if (doc.containsKey("text") && doc["text"].is<JsonArray>())
   {
     JsonArray textArray = doc["text"].as<JsonArray>();
-    parseFragmentsText(textArray, customApp.colors, customApp.fragments, customApp.color);
+    parseFragmentsText(textArray, customApp.colors, customApp.fragments, customApp.color, &customApp.blinks);
   }
   else if (doc.containsKey("text"))
   {


### PR DESCRIPTION
## What

Adds an optional per-fragment blink key `"b"` (milliseconds) to custom-app text fragments. When `b > 0`, that fragment blinks at the given interval while the other fragments stay steady. When `b` is absent or `0`, the fragment falls back to the existing app-wide `blinkText` value, so all existing payloads behave exactly as before.

## Why

Text fragments already support per-fragment color (`"c"`), but blinking is only available app-wide via `blinkText`, which blinks the **entire** text. There was no way to blink a single fragment — e.g. a clock separator `HH : MM` where only the `:` pulses (the behaviour of the built-in Time app, previously impossible to reproduce in a custom app). See #366.

## How

- `Apps.h`: add `std::vector<int> blinks` to `CustomApp`.
- `DisplayManager.cpp`: `parseFragmentsText` takes an optional `std::vector<int>*` and reads each fragment's `"b"` into it; the notification call site is unchanged (passes the default `nullptr`).
- `Apps.cpp`: both fragment render loops pick the per-fragment blink with app-wide fallback: `(i < blinks.size() && blinks[i] > 0) ? blinks[i] : ca->blink`.
- `docs/api.md`: document `"b"`.

Backward compatible; notification rendering untouched.

## Example

```json
{ "text": [ {"t":"12"}, {"t":":","b":500}, {"t":"34"} ] }
```

## Testing

Built for `ulanzi` (espressif32@6.3.0) and flashed to a TC001 via OTA. Verified by sampling the device framebuffer: with the payload above, exactly the two colon pixels toggle at 500 ms while the digit pixels stay lit. Existing single-string and app-wide `blinkText` payloads unaffected.
